### PR TITLE
Debug hooks for to the emulator (used in TheJP/vscode-backseat-debug)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,8 @@ dependencies = [
  "bitflags",
  "chrono",
  "clap",
+ "crossbeam-channel",
+ "crossbeam-utils",
  "int-enum",
  "num-format",
  "raylib",
@@ -125,6 +127,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8ad8cef104ac57b68b89df3208164d228503abbdce70f6880ffa3d970e7443a"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
+dependencies = [
+ "cfg-if 1.0.0",
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ debug = 2
 [features]
 default = ["graphics"]
 graphics = ["dep:raylib"]
+debugger = ["dep:crossbeam-channel", "dep:crossbeam-utils"]
 
 [dependencies]
 raylib = { version = "3.7", git = "https://github.com/deltaphc/raylib-rs", optional = true }
@@ -22,3 +23,5 @@ serde = { version = "1.0", features = ["derive"] }
 clap = { version = "3.2.17", features = ["derive"] }
 chrono = "0.4.19"
 int-enum = {version = "0.4", features = ["convert"] }
+crossbeam-channel = { version = "0.5", optional = true }
+crossbeam-utils = { version = "0.8", optional = true }

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -1,0 +1,329 @@
+mod segmented_reader;
+mod tcp_protocol;
+
+use std::{
+    collections::{HashSet, VecDeque},
+    thread,
+    time::Duration,
+};
+
+use crossbeam_channel::{bounded, select, tick, Receiver, Sender, TryRecvError};
+use crossbeam_utils::sync::WaitGroup;
+
+use crate::{debugger::tcp_protocol::TcpHandler, Address};
+
+use self::tcp_protocol::PollReturn;
+
+const CHANNEL_BOUND: usize = 100;
+const TCP_POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+struct Debugger {
+    receiver: Receiver<DebugMessage>,
+    breakpoint_sender: Sender<BreakpointMessage>,
+    started: bool,
+    start_notifications: Vec<WaitGroup>,
+}
+
+#[derive(Clone)]
+pub struct DebugHandle {
+    sender: Option<Sender<DebugMessage>>,
+}
+
+pub struct BreakpointHandle {
+    state: BreakpointHandleState,
+    breakpoints: HashSet<Address>,
+    sender: Option<Sender<DebugMessage>>,
+    receiver: Option<Receiver<BreakpointMessage>>,
+    receive_cache: VecDeque<BreakpointMessage>,
+}
+
+#[derive(Debug, PartialEq)]
+enum BreakpointHandleState {
+    WaitingForStart,
+    Running,
+    Breaking,
+}
+
+enum DebugMessage {
+    /// Request to stop the debugger thread.
+    Stop,
+    /// Request to wait for start and drop the sent wait group after starting.
+    WaitForStart(WaitGroup),
+    /// Notification that we hit a breakpoint and will start breaking.
+    HitBreakpoint(Address),
+    /// Notification that the debugger is (still) breaking at the given instruction address.
+    Breaking(Address),
+}
+
+enum DebuggerCommand {
+    TcpPoll,
+    HandleMessage(DebugMessage),
+}
+
+enum BreakpointMessage {
+    SetBreakpoints(Vec<Address>),
+    RemoveBreakpoints(Vec<Address>),
+    /// Continue normal execution i.e. stop breaking.
+    Continue,
+    /// Execute one instruction while breaking.
+    StepOne,
+}
+
+pub fn start_debugger() -> (DebugHandle, BreakpointHandle) {
+    let (sender, receiver) = bounded(CHANNEL_BOUND);
+    let (breakpoint_sender, breakpoint_receiver) = bounded(CHANNEL_BOUND);
+
+    thread::spawn(move || Debugger::new(receiver, breakpoint_sender).run());
+
+    (
+        DebugHandle {
+            sender: Some(sender.clone()),
+        },
+        BreakpointHandle {
+            state: BreakpointHandleState::WaitingForStart,
+            breakpoints: HashSet::new(),
+            sender: Some(sender),
+            receiver: Some(breakpoint_receiver),
+            receive_cache: VecDeque::new(),
+        },
+    )
+}
+
+impl DebugHandle {
+    pub fn dummy() -> Self {
+        Self { sender: None }
+    }
+
+    #[inline]
+    fn send(&self, message: DebugMessage) {
+        if let Some(sender) = &self.sender {
+            sender
+                .send(message)
+                .expect("Cannot send message to debug interface.");
+        }
+    }
+
+    pub fn stop(&self) {
+        self.send(DebugMessage::Stop);
+    }
+}
+
+impl BreakpointHandle {
+    pub fn dummy() -> Self {
+        Self {
+            state: BreakpointHandleState::Running,
+            breakpoints: HashSet::with_capacity(0),
+            sender: None,
+            receiver: None,
+            receive_cache: VecDeque::with_capacity(0),
+        }
+    }
+
+    pub fn before_instruction_execution(&mut self, instruction_pointer: Address) {
+        use BreakpointHandleState::*;
+
+        if self.state == WaitingForStart {
+            self.wait_for_start();
+            self.state = Running;
+            self.receive_cache.clear();
+        }
+
+        self.receive_updates_non_blocking();
+
+        let should_break = self.breakpoints.contains(&instruction_pointer);
+        if self.state != Breaking && should_break {
+            self.state = Breaking;
+            self.receive_cache.clear();
+            self.send(DebugMessage::HitBreakpoint(instruction_pointer));
+        } else if self.state == Breaking {
+            self.send(DebugMessage::Breaking(instruction_pointer));
+        }
+
+        if self.state == Breaking {
+            self.breaking();
+        }
+    }
+
+    /// Wait for start command from debugger interface
+    /// or directly continue if not in debug mode.
+    pub fn wait_for_start(&self) {
+        if self.sender.is_some() {
+            let wait_group = WaitGroup::new();
+            self.send(DebugMessage::WaitForStart(wait_group.clone()));
+            wait_group.wait();
+        }
+    }
+
+    fn breaking(&mut self) {
+        use BreakpointMessage::*;
+
+        loop {
+            while let Some(message) = self.receive_cache.pop_front() {
+                match message {
+                    StepOne => return,
+                    Continue => {
+                        self.state = BreakpointHandleState::Running;
+                        return;
+                    },
+                    SetBreakpoints(_) | RemoveBreakpoints(_) => panic!("BreakpointHandle: SetBreakpoints and RemoveBreakpoints should never be added to the message cache but handled immediately."),
+                }
+            }
+
+            self.receive_update_blocking();
+        }
+    }
+
+    #[inline]
+    fn send(&self, message: DebugMessage) {
+        if let Some(sender) = &self.sender {
+            sender
+                .send(message)
+                .expect("Cannot send message to debug interface.");
+        }
+    }
+
+    fn receive_updates_non_blocking(&mut self) {
+        loop {
+            if let Some(ref receiver) = self.receiver {
+                match receiver.try_recv() {
+                    Ok(message) => self.handle_message(message),
+                    Err(TryRecvError::Disconnected) => {
+                        panic!("Cannot receive breakpoint updates after debugger has been stopped.")
+                    }
+                    Err(TryRecvError::Empty) => break,
+                }
+            }
+        }
+    }
+
+    fn receive_update_blocking(&mut self) {
+        if let Some(ref receiver) = self.receiver {
+            match receiver.recv() {
+                Ok(message) => self.handle_message(message),
+                Err(_) => {
+                    panic!("Cannot receive breakpoint updates after debugger has been stopped.")
+                }
+            }
+        }
+    }
+
+    #[inline]
+    fn handle_message(&mut self, message: BreakpointMessage) {
+        match message {
+            BreakpointMessage::SetBreakpoints(locations) => {
+                self.breakpoints.extend(locations);
+            }
+            BreakpointMessage::RemoveBreakpoints(locations) => {
+                for location in locations {
+                    self.breakpoints.remove(&location);
+                }
+            }
+            _ => self.receive_cache.push_back(message),
+        }
+    }
+}
+
+impl Debugger {
+    fn new(receiver: Receiver<DebugMessage>, breakpoint_sender: Sender<BreakpointMessage>) -> Self {
+        Self {
+            receiver,
+            breakpoint_sender,
+            started: false,
+            start_notifications: Vec::new(),
+        }
+    }
+
+    fn run(mut self) {
+        use DebuggerCommand::*;
+
+        let mut tcp = TcpHandler::start();
+        let tcp_poll = tick(TCP_POLL_INTERVAL);
+
+        loop {
+            let command = select! {
+                recv(tcp_poll) -> _ => TcpPoll,
+                recv(self.receiver) -> message =>
+                    HandleMessage(message.expect("Debugger cannot receive message on debug interface.")),
+            };
+
+            match command {
+                TcpPoll => self.handle_poll_result(tcp.poll()),
+                HandleMessage(DebugMessage::Stop) => break,
+                HandleMessage(message) => self.handle_debug_message(message, &mut tcp),
+            }
+        }
+    }
+
+    fn handle_poll_result(&mut self, result: tcp_protocol::Result<PollReturn>) {
+        match result {
+            Ok(
+                PollReturn::Nothing | PollReturn::ClientConnected | PollReturn::ClientDisconnected,
+            ) => {}
+            Ok(PollReturn::ReceivedRequests(requests)) => {
+                for request in requests {
+                    self.handle_request(request);
+                }
+            }
+            Err(_) => self.handle_tcp_result(result),
+        }
+    }
+
+    fn handle_debug_message(&mut self, message: DebugMessage, tcp: &mut TcpHandler) {
+        match message {
+            DebugMessage::Stop => unreachable!(),
+            DebugMessage::WaitForStart(wait_group) => {
+                if !self.started {
+                    self.start_notifications.push(wait_group);
+                }
+            }
+            DebugMessage::HitBreakpoint(location) => {
+                let message = tcp_protocol::Response::HitBreakpoint { location };
+                self.handle_tcp_result(tcp.send(&message));
+            }
+            DebugMessage::Breaking(location) => {
+                let message = tcp_protocol::Response::Breaking { location };
+                self.handle_tcp_result(tcp.send(&message));
+            }
+        }
+    }
+
+    fn handle_tcp_result<T>(&self, result: tcp_protocol::Result<T>) {
+        match result {
+            Ok(_) => {}
+            Err(tcp_protocol::Error::Io(ref error)) => eprintln!("Failed TCP operation: {}", error),
+            Err(tcp_protocol::Error::Serde(ref error)) => {
+                eprintln!("Failed (de)serialisation in TCP interface: {}", error)
+            }
+        }
+    }
+
+    fn handle_request(&mut self, request: tcp_protocol::Request) {
+        match request {
+            tcp_protocol::Request::StartExecution {} => {
+                self.started = true;
+                self.start_notifications.clear(); // ==> notify all
+            }
+            tcp_protocol::Request::SetBreakpoints { locations } => {
+                self.send_to_breakpoint_handler(BreakpointMessage::SetBreakpoints(locations))
+            }
+            tcp_protocol::Request::RemoveBreakpoints { locations } => {
+                self.send_to_breakpoint_handler(BreakpointMessage::RemoveBreakpoints(locations))
+            }
+            tcp_protocol::Request::Continue {} => {
+                self.send_to_breakpoint_handler(BreakpointMessage::Continue)
+            }
+            tcp_protocol::Request::StepOne {} => {
+                self.send_to_breakpoint_handler(BreakpointMessage::StepOne)
+            }
+        }
+    }
+
+    fn send_to_breakpoint_handler(&mut self, message: BreakpointMessage) {
+        match self.breakpoint_sender.try_send(message) {
+            Ok(_) | Err(crossbeam_channel::TrySendError::Full(_)) => {}
+            Err(crossbeam_channel::TrySendError::Disconnected(_)) => {
+                panic!("Breakpoint channel closed before debugger was stopped.")
+            }
+        }
+    }
+}

--- a/src/debugger/segmented_reader.rs
+++ b/src/debugger/segmented_reader.rs
@@ -1,0 +1,315 @@
+use std::{
+    cmp::max,
+    fmt,
+    io::{self, Read},
+    ops::Range,
+};
+
+const INITIAL_BUFFER_SIZE: usize = 1024;
+
+pub struct SegmentedReader {
+    buffer: Vec<u8>,
+    length: usize,
+    next_segment_start: usize,
+    buffer_version: u32,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct Segment {
+    range: Range<usize>,
+    buffer_version: u32,
+}
+
+#[derive(Debug)]
+pub enum Error {
+    Io(io::Error),
+    Disconnected,
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+impl SegmentedReader {
+    pub fn new() -> Self {
+        Self {
+            buffer: vec![0; INITIAL_BUFFER_SIZE],
+            length: 0,
+            buffer_version: 0,
+            next_segment_start: 0,
+        }
+    }
+
+    pub fn read(&mut self, mut from: impl Read) -> Result<Vec<Segment>> {
+        self.consume_old_segments();
+        if self.length == self.buffer.len() {
+            self.grow_buffer();
+        }
+
+        let length = from
+            .read(&mut self.buffer[self.length..])
+            .map_err(Error::Io)?;
+
+        if length == 0 {
+            return Err(Error::Disconnected);
+        }
+
+        let (search_start, search_end) = (self.length, self.length + length);
+        self.length += length;
+
+        let endings = self.buffer[search_start..search_end]
+            .iter()
+            .enumerate()
+            .filter(|(_, &byte)| byte == 0)
+            .map(|(index, _)| index + search_start);
+
+        let mut segments = Vec::new();
+        for ending in endings {
+            segments.push(Segment {
+                range: self.next_segment_start..ending,
+                buffer_version: self.buffer_version,
+            });
+            self.next_segment_start = ending + 1;
+        }
+
+        Ok(segments)
+    }
+
+    pub fn segment(&self, s: &Segment) -> &[u8] {
+        if s.buffer_version != self.buffer_version {
+            panic!("Cannot access old segment after new data is read into buffer");
+        }
+        &self.buffer[s.range.clone()]
+    }
+
+    pub fn clear(&mut self) {
+        self.buffer_version += 1;
+        self.length = 0;
+        self.next_segment_start = 0;
+    }
+
+    fn consume_old_segments(&mut self) {
+        if self.next_segment_start == 0 {
+            return;
+        }
+
+        self.buffer_version += 1; // Invalidate old segments
+
+        if self.next_segment_start == self.length {
+            self.length = 0;
+            self.next_segment_start = 0;
+        } else if self.next_segment_start != 0 {
+            let buffer_size = max(
+                INITIAL_BUFFER_SIZE,
+                2 * (self.length - self.next_segment_start),
+            );
+            let mut new_buffer = vec![0; buffer_size];
+            new_buffer[0..(self.length - self.next_segment_start)]
+                .copy_from_slice(&self.buffer[self.next_segment_start..self.length]);
+
+            self.buffer = new_buffer;
+            self.length = self.length - self.next_segment_start;
+            self.next_segment_start = 0;
+        }
+    }
+
+    fn grow_buffer(&mut self) {
+        let new_size = 2 * self.buffer.len();
+        self.buffer.resize(new_size, 0);
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::Io(error) => error.fmt(f),
+            Error::Disconnected => write!(f, "input disconnected"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_returns_correct_segments() -> Result<()> {
+        let mut reader = SegmentedReader::new();
+        let read = b"hello\0world\0";
+        let segments = reader.read(&read[..])?;
+        assert_eq!(
+            &[
+                Segment {
+                    range: 0..5,
+                    buffer_version: reader.buffer_version
+                },
+                Segment {
+                    range: 6..11,
+                    buffer_version: reader.buffer_version
+                }
+            ][..],
+            &segments[..]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn read_returns_disconnected_when_reading_zero_bytes() {
+        let mut reader = SegmentedReader::new();
+        let result = reader.read(&b""[..]);
+        assert!(matches!(result, Err(Error::Disconnected)));
+    }
+
+    #[test]
+    fn segment_returns_correct_slice() -> Result<()> {
+        let mut reader = SegmentedReader::new();
+        let read = b"hello\0world\0";
+        let segments = reader.read(&read[..])?;
+        assert_eq!(2, segments.len());
+        assert_eq!(&b"hello"[..], reader.segment(&segments[0]));
+        assert_eq!(&b"world"[..], reader.segment(&segments[1]));
+
+        let mut reader = SegmentedReader::new();
+        let read = b"\0this is some text\0012345\0\0not finished yet...";
+        let segments = reader.read(&read[..])?;
+        assert_eq!(4, segments.len());
+        assert_eq!(&b""[..], reader.segment(&segments[0]));
+        assert_eq!(&b"this is some text"[..], reader.segment(&segments[1]));
+        assert_eq!(&b"012345"[..], reader.segment(&segments[2]));
+        assert_eq!(&b""[..], reader.segment(&segments[3]));
+
+        Ok(())
+    }
+
+    #[test]
+    fn segment_panics_when_given_invalid_segment() -> Result<()> {
+        let mut reader = SegmentedReader::new();
+        let read = b"hello\0world\0";
+        let mut segments = reader.read(&read[..])?;
+
+        segments[0].buffer_version += 42;
+        let panic = std::panic::catch_unwind(|| reader.segment(&segments[0]));
+        assert!(panic.is_err());
+
+        Ok(())
+    }
+
+    #[test]
+    fn multiple_reads_work_correctly() -> Result<()> {
+        let mut reader = SegmentedReader::new();
+        let read1 = b"hello\0world\0";
+        let read2 = b"simple\0case\0";
+        reader.read(&read1[..])?;
+        let segments2 = reader.read(&read2[..])?;
+
+        assert_eq!(2, segments2.len());
+        assert_eq!(&b"simple"[..], reader.segment(&segments2[0]));
+        assert_eq!(&b"case"[..], reader.segment(&segments2[1]));
+
+        Ok(())
+    }
+
+    #[test]
+    fn read_invalidates_old_segments() -> Result<()> {
+        let mut reader = SegmentedReader::new();
+        let read1 = b"hello\0world\0";
+        let read2 = b"simple\0case\0";
+        let segments1 = reader.read(&read1[..])?;
+        reader.read(&read2[..])?;
+
+        assert_eq!(2, segments1.len());
+        let panic = std::panic::catch_unwind(|| reader.segment(&segments1[0]));
+        assert!(panic.is_err());
+
+        Ok(())
+    }
+
+    #[test]
+    fn read_overlapping_segments() -> Result<()> {
+        let mut reader = SegmentedReader::new();
+        let read1 = b"hello\0world\0over";
+        let read2 = b"lapping\0case\0";
+
+        let segments1 = reader.read(&read1[..])?;
+        assert_eq!(2, segments1.len());
+        assert_eq!(&b"hello"[..], reader.segment(&segments1[0]));
+        assert_eq!(&b"world"[..], reader.segment(&segments1[1]));
+
+        let segments2 = reader.read(&read2[..])?;
+        assert_eq!(2, segments2.len());
+        assert_eq!(&b"overlapping"[..], reader.segment(&segments2[0]));
+        assert_eq!(&b"case"[..], reader.segment(&segments2[1]));
+
+        Ok(())
+    }
+
+    #[test]
+    fn multiple_reads_for_single_segment() -> Result<()> {
+        let mut reader = SegmentedReader::new();
+        let read1 = b"read1 ";
+        let read2 = b"read2 ";
+        let read3 = b"read3\0";
+
+        let segments = reader.read(&read1[..])?;
+        assert_eq!(0, segments.len());
+        let segments = reader.read(&read2[..])?;
+        assert_eq!(0, segments.len());
+        let segments = reader.read(&read3[..])?;
+        assert_eq!(1, segments.len());
+        assert_eq!(&b"read1 read2 read3"[..], reader.segment(&segments[0]));
+
+        Ok(())
+    }
+
+    #[test]
+    fn read_grows_buffer() -> Result<()> {
+        let mut reader = SegmentedReader::new();
+
+        let buffer_size = reader.buffer.len();
+        let mut read = vec![5; 3 * buffer_size];
+        *read.last_mut().unwrap() = 0;
+
+        let mut slice = &read[..];
+        let segments = loop {
+            let segments = reader.read(&mut slice)?;
+            if segments.len() != 0 {
+                break segments;
+            }
+        };
+
+        assert_eq!(1, segments.len());
+        assert_eq!(&read[0..3 * buffer_size - 1], reader.segment(&segments[0]));
+
+        Ok(())
+    }
+
+    #[test]
+    fn clear_resets_reader_correctly() -> Result<()> {
+        let mut reader = SegmentedReader::new();
+
+        let read1 = b"read1";
+        let segments = reader.read(&read1[..])?;
+        assert_eq!(0, segments.len());
+
+        let read2 = b"read2\0";
+        reader.clear();
+        let segments = reader.read(&read2[..])?;
+        assert_eq!(1, segments.len());
+        assert_eq!(&b"read2"[..], reader.segment(&segments[0]));
+
+        Ok(())
+    }
+
+    #[test]
+    fn clear_invalidates_old_segments() -> Result<()> {
+        let mut reader = SegmentedReader::new();
+
+        let read1 = b"read1\0read2";
+        let segments = reader.read(&read1[..])?;
+        assert_eq!(1, segments.len());
+
+        reader.clear();
+        let panic = std::panic::catch_unwind(|| reader.segment(&segments[0]));
+        assert!(panic.is_err());
+
+        Ok(())
+    }
+}

--- a/src/debugger/tcp_protocol.rs
+++ b/src/debugger/tcp_protocol.rs
@@ -29,6 +29,10 @@ pub enum Request {
     Continue {},
     /// Execute one instruction while breaking.
     StepOne {},
+    SetRegister {
+        register: u8,
+        value: Word,
+    },
 }
 
 #[derive(Debug, Serialize)]

--- a/src/debugger/tcp_protocol.rs
+++ b/src/debugger/tcp_protocol.rs
@@ -16,7 +16,9 @@ const DEBUGGER_PORT_PREFIX: &str = "Debugger-Port:";
 
 #[derive(Debug, Deserialize)]
 pub enum Request {
-    StartExecution {},
+    StartExecution {
+        stop_on_entry: bool,
+    },
     SetBreakpoints {
         locations: Vec<Address>,
     },
@@ -33,6 +35,7 @@ pub enum Request {
 pub enum Response {
     HitBreakpoint { location: Address },
     Breaking { location: Address },
+    Pausing { location: Address },
 }
 
 pub struct TcpHandler {

--- a/src/debugger/tcp_protocol.rs
+++ b/src/debugger/tcp_protocol.rs
@@ -7,7 +7,7 @@ use std::{
 use crossbeam_utils::Backoff;
 use serde::{Deserialize, Serialize};
 
-use crate::Address;
+use crate::{Address, Word};
 
 use super::segmented_reader::{self, Segment, SegmentedReader};
 
@@ -36,6 +36,7 @@ pub enum Response {
     HitBreakpoint { location: Address },
     Breaking { location: Address },
     Pausing { location: Address },
+    Registers { registers: Vec<Word> },
 }
 
 pub struct TcpHandler {

--- a/src/debugger/tcp_protocol.rs
+++ b/src/debugger/tcp_protocol.rs
@@ -1,0 +1,179 @@
+use std::{
+    fmt,
+    io::{self, ErrorKind, Write},
+    net::{TcpListener, TcpStream},
+};
+
+use crossbeam_utils::Backoff;
+use serde::{Deserialize, Serialize};
+
+use crate::Address;
+
+use super::segmented_reader::{self, Segment, SegmentedReader};
+
+const TCP_INTERFACE_ADDRESS: &str = "127.0.0.1:57017";
+const DEBUGGER_PORT_PREFIX: &str = "Debugger-Port:";
+
+#[derive(Debug, Deserialize)]
+pub enum Request {
+    StartExecution {},
+    SetBreakpoints {
+        locations: Vec<Address>,
+    },
+    RemoveBreakpoints {
+        locations: Vec<Address>,
+    },
+    /// Continue normal execution i.e. stop breaking.
+    Continue {},
+    /// Execute one instruction while breaking.
+    StepOne {},
+}
+
+#[derive(Debug, Serialize)]
+pub enum Response {
+    HitBreakpoint { location: Address },
+    Breaking { location: Address },
+}
+
+pub struct TcpHandler {
+    listener: TcpListener,
+    client: Option<TcpStream>,
+    reader: SegmentedReader,
+}
+
+pub enum PollReturn {
+    Nothing,
+    ClientConnected,
+    ClientDisconnected,
+    ReceivedRequests(Vec<Request>),
+}
+
+#[derive(Debug)]
+pub enum Error {
+    Io(io::Error),
+    Serde(serde_json::Error),
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+impl TcpHandler {
+    pub fn start() -> Self {
+        let listener =
+            TcpListener::bind(TCP_INTERFACE_ADDRESS).expect("Cannot open debug TCP interface.");
+        listener
+            .set_nonblocking(true)
+            .expect("Cannot set tcp listener to non-blocking.");
+
+        if let Ok(address) = listener.local_addr() {
+            println!("{}{}", DEBUGGER_PORT_PREFIX, address.port());
+        }
+
+        Self {
+            listener,
+            client: None,
+            reader: SegmentedReader::new(),
+        }
+    }
+
+    pub fn poll(&mut self) -> Result<PollReturn> {
+        match self.client {
+            None => self.tcp_accept(),
+            Some(ref mut client) => match self.reader.read(client) {
+                Ok(segments) => {
+                    let result = self.parse_requests(&segments);
+                    if result.is_err() {
+                        self.disconnect();
+                    }
+                    result
+                }
+                Err(segmented_reader::Error::Disconnected) => {
+                    self.disconnect();
+                    Ok(PollReturn::ClientDisconnected)
+                }
+                Err(segmented_reader::Error::Io(error))
+                    if error.kind() == io::ErrorKind::WouldBlock =>
+                {
+                    Ok(PollReturn::Nothing)
+                }
+                Err(segmented_reader::Error::Io(error)) => {
+                    self.disconnect();
+                    Err(Error::Io(error))
+                }
+            },
+        }
+    }
+
+    pub fn send(&mut self, message: &Response) -> Result<()> {
+        let mut json = serde_json::to_vec(message).map_err(Error::Serde)?;
+        json.push(0);
+
+        self.write_all(&json[..])
+    }
+
+    fn disconnect(&mut self) {
+        self.client = None; // Dropping the stream disconnects it, if it is still active.
+        self.reader.clear();
+    }
+
+    fn tcp_accept(&mut self) -> Result<PollReturn> {
+        match self.listener.accept() {
+            Ok((client, _)) => {
+                client.set_nodelay(true).map_err(Error::Io)?;
+                self.client = Some(client);
+                Ok(PollReturn::ClientConnected)
+            }
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => Ok(PollReturn::Nothing),
+            Err(error) => Err(Error::Io(error)),
+        }
+    }
+
+    fn parse_requests(&mut self, segments: &Vec<Segment>) -> Result<PollReturn> {
+        let mut requests = Vec::new();
+        for segment in segments {
+            let slice = self.reader.segment(segment);
+            let request: Request = serde_json::from_slice(slice).map_err(Error::Serde)?;
+            requests.push(request);
+        }
+
+        Ok(PollReturn::ReceivedRequests(requests))
+    }
+
+    /// Non-blocking version of write_all.
+    fn write_all(&mut self, mut buffer: &[u8]) -> Result<()> {
+        let client = match &mut self.client {
+            Some(client) => client,
+            None => return Ok(()),
+        };
+
+        let backoff = Backoff::new();
+        while !buffer.is_empty() {
+            match client.write(buffer) {
+                Ok(0) => {
+                    self.disconnect();
+                    return Err(Error::Io(io::Error::new(
+                        ErrorKind::WriteZero,
+                        "failed to write whole buffer",
+                    )));
+                }
+                Ok(n) => buffer = &buffer[n..],
+                Err(ref error) if error.kind() == ErrorKind::Interrupted => {}
+                Err(ref error) if error.kind() == ErrorKind::WouldBlock => backoff.spin(),
+                Err(error) => {
+                    self.disconnect();
+                    return Err(Error::Io(error));
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::Io(error) => error.fmt(f),
+            Error::Serde(error) => error.fmt(f),
+        }
+    }
+}

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -148,7 +148,7 @@ where
 
         #[cfg(feature = "debugger")]
         self.debug_handle
-            .before_instruction_execution(&self.processor);
+            .before_instruction_execution(&mut self.processor);
 
         match self.processor.execute_next_instruction(
             &mut self.memory,

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 #[cfg(feature = "debugger")]
-use crate::debugger::{BreakpointHandle, DebugHandle};
+use crate::debugger::DebugHandle;
 
 #[cfg(feature = "graphics")]
 use raylib::prelude::*;
@@ -27,8 +27,6 @@ where
     instruction_cache: InstructionCache<PeripheryImplementation<Display>>,
     #[cfg(feature = "debugger")]
     debug_handle: DebugHandle,
-    #[cfg(feature = "debugger")]
-    breakpoint_handle: BreakpointHandle,
 }
 
 impl<Display> Machine<Display>
@@ -74,7 +72,6 @@ where
                 is_halted: false,
                 instruction_cache,
                 debug_handle: DebugHandle::dummy(),
-                breakpoint_handle: BreakpointHandle::dummy(),
             }
         }
     }
@@ -150,8 +147,8 @@ where
         use crate::processor::ExecutionResult::*;
 
         #[cfg(feature = "debugger")]
-        self.breakpoint_handle
-            .before_instruction_execution(self.processor.get_instruction_pointer());
+        self.debug_handle
+            .before_instruction_execution(&self.processor);
 
         match self.processor.execute_next_instruction(
             &mut self.memory,
@@ -172,13 +169,13 @@ where
     }
 
     #[cfg(feature = "debugger")]
-    pub fn set_debug_handle(
-        &mut self,
-        debug_handle: DebugHandle,
-        breakpoint_handle: BreakpointHandle,
-    ) {
-        self.debug_handle = debug_handle;
-        self.breakpoint_handle = breakpoint_handle;
+    pub fn start_debugger(&mut self) {
+        self.debug_handle = crate::debugger::start_debugger();
+    }
+
+    #[cfg(feature = "debugger")]
+    pub fn stop_debugger(&mut self) {
+        self.debug_handle.stop();
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -430,13 +430,8 @@ fn run(rom_filename: Option<&Path>, options: RunOptions) -> Result<(), Box<dyn E
     let mut machine = Machine::new(periphery, options.exit_on_halt);
 
     #[cfg(feature = "debugger")]
-    let (debug_handle, breakpoint_handle);
-    #[cfg(feature = "debugger")]
     if options.debug {
-        (debug_handle, breakpoint_handle) = debugger::start_debugger();
-        machine.set_debug_handle(debug_handle.clone(), breakpoint_handle);
-    } else {
-        debug_handle = debugger::DebugHandle::dummy();
+        machine.start_debugger();
     }
 
     match rom_filename {
@@ -511,7 +506,9 @@ fn run(rom_filename: Option<&Path>, options: RunOptions) -> Result<(), Box<dyn E
     }
 
     #[cfg(feature = "debugger")]
-    debug_handle.stop();
+    if options.debug {
+        machine.stop_debugger();
+    }
 
     Ok(())
 }

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -57,6 +57,11 @@ pub struct Registers<const SIZE: usize>([Word; SIZE]);
 
 impl<const SIZE: usize> Registers<SIZE> {
     const _ASSERT_VALID_REGISTER_COUNT: () = assert!(SIZE - 1 < u8::MAX as usize);
+
+    #[cfg(feature = "debugger")]
+    pub fn contents(&self) -> &[Word; SIZE] {
+        &self.0
+    }
 }
 
 impl<const SIZE: usize> Index<Register> for Registers<SIZE> {


### PR DESCRIPTION
Debug hooks are not built per default but available as a feature. To build with debug hooks use: `cargo build --features debugger`.

Features:
* Pausing execution on emulator start
* Addind and removing breakpoints
* Pausing execution on reaching breakpoint
* Stepping: executing one instruction when in pause/break mode
* Continue execution after it was paused (by breakpoint or on entry)
* Reading and writing register contents