### PR TITLE
Emulator no longer freezing during debug session

### DIFF
--- a/src/machine.rs
+++ b/src/machine.rs
@@ -3,6 +3,7 @@ use std::time::Instant;
 use crate::{
     address_constants,
     cursor::{Cursor, CursorMode},
+    debugger::ShouldExecuteInstruction,
     display,
     memory::Memory,
     periphery::PeripheryImplementation,
@@ -147,8 +148,14 @@ where
         use crate::processor::ExecutionResult::*;
 
         #[cfg(feature = "debugger")]
-        self.debug_handle
-            .before_instruction_execution(&mut self.processor, &mut self.memory);
+        {
+            let result = self
+                .debug_handle
+                .before_instruction_execution(&mut self.processor, &mut self.memory);
+            if let ShouldExecuteInstruction::No = result {
+                return;
+            }
+        }
 
         match self.processor.execute_next_instruction(
             &mut self.memory,

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -3,7 +3,6 @@ use std::time::Instant;
 use crate::{
     address_constants,
     cursor::{Cursor, CursorMode},
-    debugger::ShouldExecuteInstruction,
     display,
     memory::Memory,
     periphery::PeripheryImplementation,
@@ -12,7 +11,7 @@ use crate::{
 };
 
 #[cfg(feature = "debugger")]
-use crate::debugger::DebugHandle;
+use crate::debugger::{DebugHandle, ShouldExecuteInstruction};
 
 #[cfg(feature = "graphics")]
 use raylib::prelude::*;


### PR DESCRIPTION
Made debugger hook non-blocking

This change allows, that the emulator GUI is still responsive when stopping execution by the debugger.

closes Backseating-Committee-2k/vscode-backseat-debug#3